### PR TITLE
Delay service start after multi-user.target

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=VS Code Server
-After=network.target
+After=network.target multi-user.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
Allows code server service to start after system reboot without fail: "Failed to determine user credentials: No such file or directory"

## Problem
My rather clean installation of YunoHost 11.0.11 (and previous stable one) failed to start code-server.service each time the machine was rebooted.

code-server.service journalctl:
```
-- Boot 03734629852c4297829135e8f364cbda --
Jan 05 17:11:16 systemd[1]: Started VS Code Server.
Jan 05 17:11:16 systemd[798]: code-server.service: Failed to determine user credentials: No such file or directory
Jan 05 17:11:16 systemd[798]: code-server.service: Failed at step USER spawning /opt/yunohost/code-server/bin/code-server: No such file or directory
Jan 05 17:11:16 systemd[1]: code-server.service: Main process exited, code=exited, status=217/USER
Jan 05 17:11:16 systemd[1]: code-server.service: Failed with result 'exit-code'.
```

Manual service (re)start worked.


## Solution
Turns out it just need to start some of other services first. Everything needed is most probably reachable after "multi-user.target" requirement is satisfied.
Solution was inspired by [this article on shellhacks.com](https://www.shellhacks.com/systemd-service-not-starting-status217-user/)

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests
None

## Manual test
Rebooted YunoHost machine with fully updated debian 11 and YunoHost 11.0.11 (as of 2022-01-11) and code-server.service started successfully.
