### PR TITLE
remove output from systemd conf

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -9,8 +9,6 @@ Group=__ADMIN__
 WorkingDirectory=/home/__ADMIN__
 EnvironmentFile=__INSTALL_DIR__/code-server.env
 ExecStart=__INSTALL_DIR__/bin/code-server --config __INSTALL_DIR__/config.yaml
-StandardOutput=append:/var/log/__APP__/__ADMIN__.log
-StandardError=inherit
 
 # Sandboxing options to harden security
 # Depending on specificities of your service/app, you may need to tweak these 


### PR DESCRIPTION
## Problem

- *we don't have logs in the webadmin*

## Solution

- *use the default behavior instead of  `/var/log/...`, because we don't add this file to the service in the install script, and the default behavior works out of the box*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
