### PR TITLE
Upgrade to v4.97.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.
 Run VS Code on your server and access it in the browser
 
 
-**Shipped version:** 4.96.4~ynh1
+**Shipped version:** 4.97.2~ynh1
 
 ## Screenshots
 

--- a/README_es.md
+++ b/README_es.md
@@ -21,7 +21,7 @@ No se debe editar a mano.
 Run VS Code on your server and access it in the browser
 
 
-**Versión actual:** 4.96.4~ynh1
+**Versión actual:** 4.97.2~ynh1
 
 ## Capturas
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -21,7 +21,7 @@ EZ editatu eskuz.
 Run VS Code on your server and access it in the browser
 
 
-**Paketatutako bertsioa:** 4.96.4~ynh1
+**Paketatutako bertsioa:** 4.97.2~ynh1
 
 ## Pantaila-argazkiak
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ Il NE doit PAS être modifié à la main.
 Run VS Code on your server and access it in the browser
 
 
-**Version incluse :** 4.96.4~ynh1
+**Version incluse :** 4.97.2~ynh1
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ NON debe editarse manualmente.
 Run VS Code on your server and access it in the browser
 
 
-**Versión proporcionada:** 4.96.4~ynh1
+**Versión proporcionada:** 4.97.2~ynh1
 
 ## Capturas de pantalla
 

--- a/README_id.md
+++ b/README_id.md
@@ -21,7 +21,7 @@ Ini TIDAK boleh diedit dengan tangan.
 Run VS Code on your server and access it in the browser
 
 
-**Versi terkirim:** 4.96.4~ynh1
+**Versi terkirim:** 4.97.2~ynh1
 
 ## Tangkapan Layar
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -21,7 +21,7 @@ Hij mag NIET handmatig aangepast worden.
 Run VS Code on your server and access it in the browser
 
 
-**Geleverde versie:** 4.96.4~ynh1
+**Geleverde versie:** 4.97.2~ynh1
 
 ## Schermafdrukken
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -21,7 +21,7 @@ Nie powinno być ono edytowane ręcznie.
 Run VS Code on your server and access it in the browser
 
 
-**Dostarczona wersja:** 4.96.4~ynh1
+**Dostarczona wersja:** 4.97.2~ynh1
 
 ## Zrzuty ekranu
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,7 +21,7 @@
 Run VS Code on your server and access it in the browser
 
 
-**Поставляемая версия:** 4.96.4~ynh1
+**Поставляемая версия:** 4.97.2~ynh1
 
 ## Снимки экрана
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -21,7 +21,7 @@
 Run VS Code on your server and access it in the browser
 
 
-**分发版本：** 4.96.4~ynh1
+**分发版本：** 4.97.2~ynh1
 
 ## 截图
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "code-server"
 description.en = "Run VS Code on your server and access it in the browser"
 description.fr = "Lancez VS Code sur votre serveur et accédez-y depuis votre navigateur"
 
-version = "4.96.4~ynh1"
+version = "4.97.2~ynh1"
 
 maintainers = ["Tagada"]
 
@@ -36,12 +36,12 @@ ram.runtime = "100M"
 
 [resources]
         [resources.sources.main]
-        amd64.url = "https://github.com/coder/code-server/releases/download/v4.96.4/code-server-4.96.4-linux-amd64.tar.gz"
-        amd64.sha256 = "b3f9025d00f2cdf61caf83945ef7225d4a3eb576c4c007e45868f45713e39c8e"
-        arm64.url = "https://github.com/coder/code-server/releases/download/v4.96.4/code-server-4.96.4-linux-arm64.tar.gz"
-        arm64.sha256 = "8471a70ac790ce43c302c43451e45eb2cf000a927db5bb2c8a9899b72e32fff6"
-        armhf.url = "https://github.com/coder/code-server/releases/download/v4.96.4/code-server-4.96.4-linux-armv7l.tar.gz"
-        armhf.sha256 = "2ef31b1388f817ff2ca481c6580baa2dd8647cbe92bf8fdff182f5b1fedadd38"
+        amd64.url = "https://github.com/coder/code-server/releases/download/v4.97.2/code-server-4.97.2-linux-amd64.tar.gz"
+        amd64.sha256 = "c7d5e389be56e54d300ef60610a4c877fe54cf62f0df4bb6fc2e3f04618009eb"
+        arm64.url = "https://github.com/coder/code-server/releases/download/v4.97.2/code-server-4.97.2-linux-arm64.tar.gz"
+        arm64.sha256 = "e60578f9c628a2296a20e9e4d4142559e850ac934bb7e7985425c095557a9212"
+        armhf.url = "https://github.com/coder/code-server/releases/download/v4.97.2/code-server-4.97.2-linux-armv7l.tar.gz"
+        armhf.sha256 = "1beb7b4553dc5da9445c63e9b6aeac181227db52b691e968713e4524e93604ce"
 
         autoupdate.strategy = "latest_github_release"
         autoupdate.asset.arm64 = "code-server-.*-linux-arm64.tar.gz"


### PR DESCRIPTION
Upgrade sources
- `main` v4.97.2: https://github.com/coder/code-server/releases/tag/v4.97.2

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
