### PR TITLE
Upgrade to v4.98.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.
 Run VS Code on your server and access it in the browser
 
 
-**Shipped version:** 4.98.0~ynh1
+**Shipped version:** 4.98.2~ynh1
 
 ## Screenshots
 

--- a/README_es.md
+++ b/README_es.md
@@ -21,7 +21,7 @@ No se debe editar a mano.
 Run VS Code on your server and access it in the browser
 
 
-**Versión actual:** 4.98.0~ynh1
+**Versión actual:** 4.98.2~ynh1
 
 ## Capturas
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -21,7 +21,7 @@ EZ editatu eskuz.
 Run VS Code on your server and access it in the browser
 
 
-**Paketatutako bertsioa:** 4.98.0~ynh1
+**Paketatutako bertsioa:** 4.98.2~ynh1
 
 ## Pantaila-argazkiak
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ Il NE doit PAS être modifié à la main.
 Run VS Code on your server and access it in the browser
 
 
-**Version incluse :** 4.98.0~ynh1
+**Version incluse :** 4.98.2~ynh1
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ NON debe editarse manualmente.
 Run VS Code on your server and access it in the browser
 
 
-**Versión proporcionada:** 4.98.0~ynh1
+**Versión proporcionada:** 4.98.2~ynh1
 
 ## Capturas de pantalla
 

--- a/README_id.md
+++ b/README_id.md
@@ -21,7 +21,7 @@ Ini TIDAK boleh diedit dengan tangan.
 Run VS Code on your server and access it in the browser
 
 
-**Versi terkirim:** 4.98.0~ynh1
+**Versi terkirim:** 4.98.2~ynh1
 
 ## Tangkapan Layar
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -21,7 +21,7 @@ Hij mag NIET handmatig aangepast worden.
 Run VS Code on your server and access it in the browser
 
 
-**Geleverde versie:** 4.98.0~ynh1
+**Geleverde versie:** 4.98.2~ynh1
 
 ## Schermafdrukken
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -21,7 +21,7 @@ Nie powinno być ono edytowane ręcznie.
 Run VS Code on your server and access it in the browser
 
 
-**Dostarczona wersja:** 4.98.0~ynh1
+**Dostarczona wersja:** 4.98.2~ynh1
 
 ## Zrzuty ekranu
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,7 +21,7 @@
 Run VS Code on your server and access it in the browser
 
 
-**Поставляемая версия:** 4.98.0~ynh1
+**Поставляемая версия:** 4.98.2~ynh1
 
 ## Снимки экрана
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -21,7 +21,7 @@
 Run VS Code on your server and access it in the browser
 
 
-**分发版本：** 4.98.0~ynh1
+**分发版本：** 4.98.2~ynh1
 
 ## 截图
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "code-server"
 description.en = "Run VS Code on your server and access it in the browser"
 description.fr = "Lancez VS Code sur votre serveur et accédez-y depuis votre navigateur"
 
-version = "4.98.0~ynh1"
+version = "4.98.2~ynh1"
 
 maintainers = ["Tagada"]
 
@@ -36,12 +36,12 @@ ram.runtime = "100M"
 
 [resources]
         [resources.sources.main]
-        amd64.url = "https://github.com/coder/code-server/releases/download/v4.98.0/code-server-4.98.0-linux-amd64.tar.gz"
-        amd64.sha256 = "e11e181a2f1bda14cf358404b670a26ea64d4a5bd8efb68ebb8787ad54f2512a"
-        arm64.url = "https://github.com/coder/code-server/releases/download/v4.98.0/code-server-4.98.0-linux-arm64.tar.gz"
-        arm64.sha256 = "06aff3443277189baf2bbbab14b4ea3823553569c70c37a55c440ae9753a9779"
-        armhf.url = "https://github.com/coder/code-server/releases/download/v4.98.0/code-server-4.98.0-linux-armv7l.tar.gz"
-        armhf.sha256 = "c564d15dee782b3523b2c9b8378f19dbcda9614348396cfd6aa6ed1ba47c35d9"
+        amd64.url = "https://github.com/coder/code-server/releases/download/v4.98.2/code-server-4.98.2-linux-amd64.tar.gz"
+        amd64.sha256 = "592acabf2f16210f4aec62d0390b2e3a392b7013068f97de72a14ce87d4279ff"
+        arm64.url = "https://github.com/coder/code-server/releases/download/v4.98.2/code-server-4.98.2-linux-arm64.tar.gz"
+        arm64.sha256 = "bf31ba7e59c1ef3fc6a131adb3723812a0d41e971ba959bb2aa85b7a3ed27550"
+        armhf.url = "https://github.com/coder/code-server/releases/download/v4.98.2/code-server-4.98.2-linux-armv7l.tar.gz"
+        armhf.sha256 = "3c35522c583e1d2fc2498c7a71c324c1984f340499c1042e1b4bc2e4d6b53d14"
 
         autoupdate.strategy = "latest_github_release"
         autoupdate.asset.arm64 = "code-server-.*-linux-arm64.tar.gz"


### PR DESCRIPTION
Upgrade sources
- `main` v4.98.2: https://github.com/coder/code-server/releases/tag/v4.98.2

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
