### PR TITLE
Upgrade to v4.99.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Run VS Code on your server and access it in the browser
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://coder.com)
-![Version: 4.98.2~ynh2](https://img.shields.io/badge/Version-4.98.2~ynh2-rgba(0,150,0,1)?style=for-the-badge)
+![Version: 4.99.1~ynh1](https://img.shields.io/badge/Version-4.99.1~ynh1-rgba(0,150,0,1)?style=for-the-badge)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/code-server"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "code-server"
 description.en = "Run VS Code on your server and access it in the browser"
 description.fr = "Lancez VS Code sur votre serveur et accédez-y depuis votre navigateur"
 
-version = "4.98.2~ynh2"
+version = "4.99.1~ynh1"
 
 maintainers = ["Tagada"]
 
@@ -41,12 +41,12 @@ ram.runtime = "100M"
 
 [resources]
     [resources.sources.main]
-    amd64.url = "https://github.com/coder/code-server/releases/download/v4.98.2/code-server-4.98.2-linux-amd64.tar.gz"
-    amd64.sha256 = "592acabf2f16210f4aec62d0390b2e3a392b7013068f97de72a14ce87d4279ff"
-    arm64.url = "https://github.com/coder/code-server/releases/download/v4.98.2/code-server-4.98.2-linux-arm64.tar.gz"
-    arm64.sha256 = "bf31ba7e59c1ef3fc6a131adb3723812a0d41e971ba959bb2aa85b7a3ed27550"
-    armhf.url = "https://github.com/coder/code-server/releases/download/v4.98.2/code-server-4.98.2-linux-armv7l.tar.gz"
-    armhf.sha256 = "3c35522c583e1d2fc2498c7a71c324c1984f340499c1042e1b4bc2e4d6b53d14"
+    amd64.url = "https://github.com/coder/code-server/releases/download/v4.99.1/code-server-4.99.1-linux-amd64.tar.gz"
+    amd64.sha256 = "90eae240b05cc7c9f214b0734bf3ed964060bf6fca9301a81a48255abbaee291"
+    arm64.url = "https://github.com/coder/code-server/releases/download/v4.99.1/code-server-4.99.1-linux-arm64.tar.gz"
+    arm64.sha256 = "a8099cc5025d9f3781c71a9b81fd013e69d32ba672c85c99a5a252724a601b66"
+    armhf.url = "https://github.com/coder/code-server/releases/download/v4.99.1/code-server-4.99.1-linux-armv7l.tar.gz"
+    armhf.sha256 = "d34472a4b529debf8b112ff1b01fce58b77b0f6c8c5d2580c9080950ffc105b7"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset.arm64 = "code-server-.*-linux-arm64.tar.gz"

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "code-server"
 description.en = "Run VS Code on your server and access it in the browser"
 description.fr = "Lancez VS Code sur votre serveur et accédez-y depuis votre navigateur"
 
-version = "4.99.1~ynh1"
+version = "4.99.2~ynh1"
 
 maintainers = ["Tagada"]
 
@@ -41,12 +41,12 @@ ram.runtime = "100M"
 
 [resources]
     [resources.sources.main]
-    amd64.url = "https://github.com/coder/code-server/releases/download/v4.99.1/code-server-4.99.1-linux-amd64.tar.gz"
-    amd64.sha256 = "90eae240b05cc7c9f214b0734bf3ed964060bf6fca9301a81a48255abbaee291"
-    arm64.url = "https://github.com/coder/code-server/releases/download/v4.99.1/code-server-4.99.1-linux-arm64.tar.gz"
-    arm64.sha256 = "a8099cc5025d9f3781c71a9b81fd013e69d32ba672c85c99a5a252724a601b66"
-    armhf.url = "https://github.com/coder/code-server/releases/download/v4.99.1/code-server-4.99.1-linux-armv7l.tar.gz"
-    armhf.sha256 = "d34472a4b529debf8b112ff1b01fce58b77b0f6c8c5d2580c9080950ffc105b7"
+    amd64.url = "https://github.com/coder/code-server/releases/download/v4.99.2/code-server-4.99.2-linux-amd64.tar.gz"
+    amd64.sha256 = "528701df7df747ea77711c1c48e69642fb8234b36920a6412433f93691210542"
+    arm64.url = "https://github.com/coder/code-server/releases/download/v4.99.2/code-server-4.99.2-linux-arm64.tar.gz"
+    arm64.sha256 = "63cda9e18893e1b73fb944e97e4b3d89de749d4335a38f8bfddf2052f10a4da3"
+    armhf.url = "https://github.com/coder/code-server/releases/download/v4.99.2/code-server-4.99.2-linux-armv7l.tar.gz"
+    armhf.sha256 = "4ac1068113d968fea5c8784d94438ccb5ba580f4a2af010136e0a04c7ba87cde"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset.arm64 = "code-server-.*-linux-arm64.tar.gz"


### PR DESCRIPTION
Upgrade sources
- `main` v4.99.2: https://github.com/coder/code-server/releases/tag/v4.99.2

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
