### PR TITLE
essai avec le path

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -35,6 +35,10 @@ ram.runtime = "100M"
     [install.domain]
     type = "domain"
 
+    [install.path]
+    type = "path"
+    default = "/code"
+
     [install.admin]
     type = "user"
 


### PR DESCRIPTION
## Problem

- I wanted to be able to access VS code from a subdirectory path of one domain

## Solution

- I added the path option in the manifest. turns out that's it

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
