### PR TITLE
v4.123.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Run VS Code on your server and access it in the browser
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://coder.com)
-[![Version: 4.121.0~ynh1](https://img.shields.io/badge/Version-4.121.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/code-server/)
+[![Version: 4.123.0~ynh1](https://img.shields.io/badge/Version-4.123.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/code-server/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/code-server"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/doc/PRE_UPGRADE.d/4.123.0~ynh1.md
+++ b/doc/PRE_UPGRADE.d/4.123.0~ynh1.md
@@ -1,0 +1,1 @@
+Due to upstream VSCode dropping `armhf` support `code-server` is no longer available for this platform. See upstream announcements [1](https://github.com/coder/code-server/releases/tag/v4.123.0) [2](https://code.visualstudio.com/updates/v1_122#_remote-development)

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "code-server"
 description.en = "Run VS Code on your server and access it in the browser"
 description.fr = "Lancez VS Code sur votre serveur et accédez-y depuis votre navigateur"
 
-version = "4.121.0~ynh1"
+version = "4.123.0~ynh1"
 
 maintainers = ["Tagada"]
 
@@ -21,7 +21,7 @@ code = "https://github.com/coder/code-server"
 [integration]
 yunohost = ">= 12.1.38"
 helpers_version = "2.1"
-architectures = ["amd64", "arm64", "armhf"]
+architectures = ["amd64", "arm64"]
 multi_instance = true
 
 ldap = false
@@ -44,17 +44,14 @@ ram.runtime = "100M"
 
 [resources]
     [resources.sources.main]
-    amd64.url = "https://github.com/coder/code-server/releases/download/v4.121.0/code-server-4.121.0-linux-amd64.tar.gz"
-    amd64.sha256 = "3860893f15376e5f984492c5c92e87c51975d67e3902410f422823d9f60e06af"
-    arm64.url = "https://github.com/coder/code-server/releases/download/v4.121.0/code-server-4.121.0-linux-arm64.tar.gz"
-    arm64.sha256 = "de5101a3c1f86b3853431d6920dcf4daaca879f613dec9139496099e31baa569"
-    armhf.url = "https://github.com/coder/code-server/releases/download/v4.121.0/code-server-4.121.0-linux-armv7l.tar.gz"
-    armhf.sha256 = "5c923afef1b4025762a34e4bb351cd7a03385e0af6be4e40af32065f9c476a49"
+    amd64.url = "https://github.com/coder/code-server/releases/download/v4.123.0/code-server-4.123.0-linux-amd64.tar.gz"
+    amd64.sha256 = "e54325a6439652f188203fb80a25c303b87f153550e9eee0c078b798b791d657"
+    arm64.url = "https://github.com/coder/code-server/releases/download/v4.123.0/code-server-4.123.0-linux-arm64.tar.gz"
+    arm64.sha256 = "855bdd7b8f522399e951c33a885a138ecf392427fb4464669ee55c9cc8fcb5f3"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset.arm64 = "code-server-.*-linux-arm64.tar.gz"
     autoupdate.asset.amd64 = "code-server-.*-linux-amd64.tar.gz"
-    autoupdate.asset.armhf = "code-server-.*-linux-armv7l.tar.gz"
 
     [resources.system_user]
 


### PR DESCRIPTION
## Problem

- New version, with dropped `armhf` support

## Solution

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
